### PR TITLE
feat: support recursive manifest discovery in srcDir

### DIFF
--- a/docs/2026-02-04/nested-dir.md
+++ b/docs/2026-02-04/nested-dir.md
@@ -1,0 +1,3 @@
+`srcDir` の中にあるディレクトリは再帰的に探索し、manifest ファイルがあった場合には同期対象とするように改修してください
+
+e.g. `<srcDir>/foo/bar/manifest.json` に定義されたブックマークは `<targetFolder>/foo/bar` 内に作成する

--- a/lib/bookmarks/api.ts
+++ b/lib/bookmarks/api.ts
@@ -73,3 +73,25 @@ export const getBookmarksInFolder = async (
 	const children = await browser.bookmarks.getChildren(folderId);
 	return children.filter((c) => c.url !== undefined);
 };
+
+/**
+ * Get or create a subfolder within a parent folder.
+ * Returns the folder ID.
+ */
+export const getOrCreateFolder = async (
+	parentFolderId: string,
+	folderName: string,
+): Promise<string> => {
+	const children = await browser.bookmarks.getChildren(parentFolderId);
+
+	const existing = children.find((c) => !c.url && c.title === folderName);
+	if (existing) {
+		return existing.id;
+	}
+
+	const newFolder = await browser.bookmarks.create({
+		parentId: parentFolderId,
+		title: folderName,
+	});
+	return newFolder.id;
+};

--- a/lib/bookmarks/sync.ts
+++ b/lib/bookmarks/sync.ts
@@ -1,5 +1,10 @@
 import type { ResolvedBookmark } from "../types/manifest.ts";
-import { getBookmarksInFolder } from "./api.ts";
+import { getBookmarksInFolder, getOrCreateFolder } from "./api.ts";
+
+export type SyncTarget = {
+	bookmarks: ResolvedBookmark[];
+	subfolderPath?: string;
+};
 
 /**
  * Sync resolved bookmarks to a Chrome bookmark folder.
@@ -26,4 +31,41 @@ export const syncBookmarksToFolder = async (
 	}
 
 	return bookmarks.length;
+};
+
+/**
+ * Sync multiple bookmark sets to different subfolders within a target folder.
+ * Cleans up old subfolders that are no longer in use.
+ */
+export const syncBookmarksToSubfolders = async (
+	targetFolderId: string,
+	syncTargets: SyncTarget[],
+): Promise<number> => {
+	const allChildren = await browser.bookmarks.getChildren(targetFolderId);
+	for (const child of allChildren) {
+		await browser.bookmarks.removeTree(child.id);
+	}
+
+	let totalBookmarks = 0;
+	for (const syncTarget of syncTargets) {
+		let folderId = targetFolderId;
+
+		if (syncTarget.subfolderPath && syncTarget.subfolderPath !== "") {
+			const pathParts = syncTarget.subfolderPath.split("/");
+			for (const part of pathParts) {
+				folderId = await getOrCreateFolder(folderId, part);
+			}
+		}
+
+		for (const bm of syncTarget.bookmarks) {
+			await browser.bookmarks.create({
+				parentId: folderId,
+				title: bm.name,
+				url: bm.url,
+			});
+			totalBookmarks++;
+		}
+	}
+
+	return totalBookmarks;
 };

--- a/lib/github/api.ts
+++ b/lib/github/api.ts
@@ -134,3 +134,47 @@ export const fetchLatestCommitSha = async (
 
 	return commits[0].sha;
 };
+
+export type ManifestLocation = {
+	path: string;
+	relativePath: string;
+};
+
+/**
+ * Recursively find all manifest.json files within a directory.
+ */
+export const findManifestFiles = async (
+	token: string,
+	owner: string,
+	repo: string,
+	path: string,
+): Promise<ManifestLocation[]> => {
+	const results: ManifestLocation[] = [];
+
+	const traverse = async (
+		currentPath: string,
+		relativePath: string,
+	): Promise<void> => {
+		const contents = await fetchRepoContents(token, owner, repo, currentPath);
+
+		for (const item of contents) {
+			const itemRelativePath = relativePath
+				? `${relativePath}/${item.name}`
+				: item.name;
+
+			if (item.type === "dir") {
+				await traverse(item.path, itemRelativePath);
+			} else if (item.name === "manifest.json") {
+				results.push({
+					path: item.path,
+					relativePath: relativePath,
+				});
+			}
+		}
+	};
+
+	const initialPath = path || "";
+	await traverse(initialPath, "");
+
+	return results;
+};

--- a/lib/sync/sync-connection.ts
+++ b/lib/sync/sync-connection.ts
@@ -1,6 +1,13 @@
 import { folderExists } from "../bookmarks/api.ts";
-import { syncBookmarksToFolder } from "../bookmarks/sync.ts";
-import { fetchFileContent, fetchLatestCommitSha } from "../github/api.ts";
+import {
+	type SyncTarget,
+	syncBookmarksToSubfolders,
+} from "../bookmarks/sync.ts";
+import {
+	fetchFileContent,
+	fetchLatestCommitSha,
+	findManifestFiles,
+} from "../github/api.ts";
 import { parseManifest } from "../manifest/parser.ts";
 import { updateConnection } from "../storage/connections.ts";
 import type { Connection } from "../types/connection.ts";
@@ -22,18 +29,15 @@ export const syncConnection = async (
 	options?: { force?: boolean },
 ): Promise<SyncResult> => {
 	try {
-		// 1. Validate target folder exists
 		if (!(await folderExists(connection.targetFolderId))) {
 			const error = "Target folder does not exist";
 			await updateConnection(connection.id, { lastSyncError: error });
 			return { success: false, error };
 		}
 
-		// Normalize srcDir: strip leading slash for API paths
 		const apiPath =
 			connection.srcDir === "/" ? "" : connection.srcDir.replace(/^\//, "");
 
-		// 2. Fetch latest commit SHA
 		const commitSha = await fetchLatestCommitSha(
 			token,
 			connection.repoOwner,
@@ -41,42 +45,57 @@ export const syncConnection = async (
 			apiPath,
 		);
 
-		// 3. Skip check
 		if (!options?.force && commitSha === connection.lastSyncedCommitSha) {
 			return { success: true, skipped: true };
 		}
 
-		// 4. Fetch manifest.json
-		const manifestPath = apiPath ? `${apiPath}/manifest.json` : "manifest.json";
-		const manifestContent = await fetchFileContent(
+		const manifestLocations = await findManifestFiles(
 			token,
 			connection.repoOwner,
 			connection.repoName,
-			manifestPath,
+			apiPath,
 		);
 
-		if (manifestContent === null) {
-			const error = `srcDir "${connection.srcDir}" does not contain manifest.json`;
+		if (manifestLocations.length === 0) {
+			const error = `No manifest.json files found in srcDir "${connection.srcDir}"`;
 			await updateConnection(connection.id, { lastSyncError: error });
 			return { success: false, error };
 		}
 
-		// 5. Parse and resolve bookmarks
-		const bookmarks = await parseManifest(
-			manifestContent,
-			connection.srcDir,
-			token,
-			connection.repoOwner,
-			connection.repoName,
-		);
+		const syncTargets: SyncTarget[] = [];
+		for (const manifestLoc of manifestLocations) {
+			const manifestContent = await fetchFileContent(
+				token,
+				connection.repoOwner,
+				connection.repoName,
+				manifestLoc.path,
+			);
 
-		// 6. Sync to target folder
-		const count = await syncBookmarksToFolder(
+			if (manifestContent === null) {
+				continue;
+			}
+
+			const manifestDir = `/${manifestLoc.path.replace(/\/manifest\.json$/, "")}`;
+
+			const bookmarks = await parseManifest(
+				manifestContent,
+				manifestDir,
+				token,
+				connection.repoOwner,
+				connection.repoName,
+			);
+
+			syncTargets.push({
+				bookmarks,
+				subfolderPath: manifestLoc.relativePath,
+			});
+		}
+
+		const count = await syncBookmarksToSubfolders(
 			connection.targetFolderId,
-			bookmarks,
+			syncTargets,
 		);
 
-		// 7. Update connection state
 		await updateConnection(connection.id, {
 			lastSyncedAt: new Date().toISOString(),
 			lastSyncedCommitSha: commitSha,


### PR DESCRIPTION
Add recursive manifest.json discovery within srcDir. Each manifest's
bookmarks are now created in corresponding subfolders, preserving
the directory structure from the repository.

- Add findManifestFiles() to recursively locate all manifest.json files
- Add getOrCreateFolder() to create nested bookmark folders
- Add syncBookmarksToSubfolders() to sync bookmarks to subfolders
- Update syncConnection() to handle multiple manifests

Example:
  <srcDir>/foo/bar/manifest.json → <targetFolder>/foo/bar/
