### PR TITLE
chore: align input/dropdown surfaces and swap in octicon chevron

### DIFF
--- a/entrypoints/options/components/AddConnectionModal.tsx
+++ b/entrypoints/options/components/AddConnectionModal.tsx
@@ -108,7 +108,7 @@ export const AddConnectionModal = ({
 						value={srcDir}
 						placeholder="/"
 						onChange={(e) => setSrcDir(e.target.value)}
-						className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-pink-500 focus:outline-none"
+						className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-pink-500 focus:outline-none"
 					/>
 				</label>
 

--- a/entrypoints/options/components/FolderSelect.tsx
+++ b/entrypoints/options/components/FolderSelect.tsx
@@ -59,7 +59,7 @@ export const FolderSelect = ({ folders, value, onChange, disabled }: Props) => {
 									onChange(f.id, f.path);
 									setOpen(false);
 								}}
-								className={`w-full px-3 py-1.5 text-left text-sm ${f.id === value ? "bg-pink-500/10 text-pink-400" : "text-zinc-400 hover:bg-zinc-700"}`}
+								className={`w-full px-3 py-1.5 text-left text-sm ${f.id === value ? "bg-pink-500/10 text-pink-400" : "text-zinc-400 hover:bg-zinc-800"}`}
 							>
 								{f.path}
 							</button>

--- a/entrypoints/options/components/RepoCombobox.tsx
+++ b/entrypoints/options/components/RepoCombobox.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Repository } from "../../../lib/github/types.ts";
+import { ChevronDownIcon } from "@primer/octicons-react";
 
 type Props = {
 	repos: Repository[];
@@ -35,7 +36,7 @@ export const RepoCombobox = ({ repos, loading, value, onChange }: Props) => {
 	return (
 		<div ref={containerRef} className="relative">
 			<div
-				className={`flex items-center rounded-md border bg-zinc-800 ${open ? "border-pink-500" : "border-zinc-700"}`}
+				className={`flex items-center px-3 py-1.5 rounded-md border bg-zinc-900 ${open ? "border-pink-500" : "border-zinc-700"}`}
 			>
 				<input
 					type="text"
@@ -46,13 +47,13 @@ export const RepoCombobox = ({ repos, loading, value, onChange }: Props) => {
 						setOpen(true);
 					}}
 					onFocus={() => setOpen(true)}
-					className="flex-1 bg-transparent px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-500 outline-none"
+					className="flex-1 bg-transparent text-sm text-zinc-100 placeholder-zinc-500 outline-none"
 				/>
-				<span className="pr-3 text-xs text-zinc-600">▾</span>
+				<ChevronDownIcon className="text-zinc-600" />
 			</div>
 
 			{open && (
-				<div className="absolute z-20 mt-1 w-full max-h-48 overflow-y-auto rounded-md border border-zinc-700 bg-zinc-800">
+				<div className="absolute z-20 mt-1 w-full max-h-48 overflow-y-auto rounded-md border border-zinc-700 bg-zinc-900">
 					{loading ? (
 						<p className="px-3 py-2 text-xs text-zinc-500">Loading…</p>
 					) : filtered.length === 0 ? (
@@ -71,7 +72,7 @@ export const RepoCombobox = ({ repos, loading, value, onChange }: Props) => {
 									setQuery("");
 									setOpen(false);
 								}}
-								className="w-full px-3 py-1.5 text-left text-sm text-zinc-400 hover:bg-zinc-700"
+								className="w-full px-3 py-1.5 text-left text-sm text-zinc-400 hover:bg-zinc-800"
 							>
 								{repo.full_name}
 							</button>


### PR DESCRIPTION
## Summary

- Deepen input and dropdown backgrounds from `zinc-800` → `zinc-900` across `AddConnectionModal`, `FolderSelect`, and `RepoCombobox` to match the rest of the options page.
- Shift hover states from `zinc-700` → `zinc-800` to keep contrast against the darker surfaces.
- Consolidate padding onto the `RepoCombobox` wrapper `<div>` instead of the inner `<input>`, so it applies uniformly around the chevron icon.
- Replace the text-based `▾` chevron with `<ChevronDownIcon>` from `@primer/octicons-react`, consistent with the icon library already adopted in the codebase.

## Test plan

- [ ] Open the Add Connection modal — srcDir input background matches the page surface
- [ ] Open the repo combobox — dropdown list and trigger both render at `zinc-900`; hover states appear at `zinc-800`
- [ ] Open the folder selector — hover states appear at `zinc-800`; selected folder highlight is unchanged
- [ ] Chevron icon renders and is visually aligned with the input text