### PR TITLE
refactor: add cursor-pointer and transition-colors to interactive elements

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -40,7 +40,7 @@ const ToastList = ({
 				<button
 					type="button"
 					onClick={() => onRemove(t.id)}
-					className="ml-auto text-zinc-500 hover:text-zinc-400"
+					className="ml-auto cursor-pointer text-zinc-500 transition-colors hover:text-zinc-400"
 				>
 					×
 				</button>

--- a/entrypoints/options/components/AddConnectionModal.tsx
+++ b/entrypoints/options/components/AddConnectionModal.tsx
@@ -108,7 +108,7 @@ export const AddConnectionModal = ({
 						value={srcDir}
 						placeholder="/"
 						onChange={(e) => setSrcDir(e.target.value)}
-						className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-pink-500 focus:outline-none"
+						className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 font-mono text-sm text-zinc-100 placeholder-zinc-600 transition-colors focus:border-pink-500 focus:outline-none"
 					/>
 				</label>
 
@@ -136,7 +136,7 @@ export const AddConnectionModal = ({
 					<button
 						type="button"
 						onClick={onClose}
-						className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400"
+						className="cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400 transition-colors hover:bg-zinc-700"
 					>
 						Cancel
 					</button>
@@ -144,7 +144,7 @@ export const AddConnectionModal = ({
 						type="button"
 						onClick={() => void handleAdd()}
 						disabled={submitting || !repo || !targetFolderId}
-						className="rounded-md bg-pink-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-pink-600 disabled:cursor-not-allowed disabled:opacity-40"
+						className="cursor-pointer rounded-md bg-pink-500 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-pink-600 disabled:cursor-not-allowed disabled:opacity-40"
 					>
 						Add
 					</button>

--- a/entrypoints/options/components/ConnectionCard.tsx
+++ b/entrypoints/options/components/ConnectionCard.tsx
@@ -162,7 +162,7 @@ export const ConnectionCard = ({
 						<button
 							type="button"
 							onClick={onSignIn}
-							className="mb-3 rounded border border-yellow-500/20 bg-yellow-500/10 px-2.5 py-0.5 text-sm text-yellow-400"
+							className="mb-3 cursor-pointer rounded border border-yellow-500/20 bg-yellow-500/10 px-2.5 py-0.5 text-sm text-yellow-400 transition-colors hover:bg-yellow-500/20"
 						>
 							Sign in required
 						</button>
@@ -174,7 +174,7 @@ export const ConnectionCard = ({
 							type="button"
 							onClick={handleToggle}
 							disabled={!authenticated}
-							className={`relative h-5 w-9 rounded-full transition-colors disabled:opacity-50 ${connection.enabled ? "bg-pink-500" : "bg-zinc-700"}`}
+							className={`relative h-5 w-9 cursor-pointer rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${connection.enabled ? "bg-pink-500" : "bg-zinc-700"}`}
 						>
 							<span
 								className="absolute top-0.5 inline-block h-4 w-4 rounded-full bg-white shadow shadow-black/40 transition-all"
@@ -199,7 +199,7 @@ export const ConnectionCard = ({
 							placeholder="/"
 							onChange={(e) => setSrcDir(e.target.value)}
 							disabled={disabled || !connection.enabled}
-							className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-pink-500 focus:outline-none disabled:opacity-40"
+							className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 font-mono text-sm text-zinc-100 placeholder-zinc-600 transition-colors focus:border-pink-500 focus:outline-none disabled:opacity-40"
 						/>
 					</label>
 
@@ -231,7 +231,7 @@ export const ConnectionCard = ({
 								type="button"
 								onClick={() => void handleSave()}
 								disabled={disabled || !connection.enabled}
-								className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-400 hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
+								className="cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
 							>
 								Save
 							</button>
@@ -240,7 +240,7 @@ export const ConnectionCard = ({
 							type="button"
 							onClick={() => setDisconnectOpen(true)}
 							disabled={disabled}
-							className="rounded-md px-2.5 py-1.5 text-sm text-red-400 hover:text-red-300 disabled:opacity-40"
+							className="cursor-pointer rounded-md px-2.5 py-1.5 text-sm text-red-400 transition-colors hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-40"
 						>
 							Disconnect
 						</button>

--- a/entrypoints/options/components/ConnectionList.tsx
+++ b/entrypoints/options/components/ConnectionList.tsx
@@ -50,7 +50,7 @@ export const ConnectionList = ({
 		<button
 			type="button"
 			onClick={onAddClick}
-			className="flex items-center justify-center gap-2 rounded-md border border-dashed border-zinc-700 px-4 py-4 text-sm text-zinc-500 hover:border-pink-500 hover:text-pink-400"
+			className="cursor-pointer flex items-center justify-center gap-2 rounded-md border border-dashed border-zinc-700 px-4 py-4 text-sm text-zinc-500 transition-colors hover:border-pink-500 hover:text-pink-400"
 		>
 			<PlusIcon />
 			Add repository

--- a/entrypoints/options/components/DisconnectConfirmModal.tsx
+++ b/entrypoints/options/components/DisconnectConfirmModal.tsx
@@ -29,14 +29,14 @@ export const DisconnectConfirmModal = ({
 					<button
 						type="button"
 						onClick={onClose}
-						className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400"
+						className="cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400 transition-colors hover:bg-zinc-700"
 					>
 						Cancel
 					</button>
 					<button
 						type="button"
 						onClick={onConfirm}
-						className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-400 hover:bg-red-500/20"
+						className="cursor-pointer rounded-md border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/20"
 					>
 						Disconnect
 					</button>

--- a/entrypoints/options/components/ErrorSection.tsx
+++ b/entrypoints/options/components/ErrorSection.tsx
@@ -14,7 +14,7 @@ export const ErrorSection = ({ error, onRetry }: Props) => {
 					<button
 						type="button"
 						onClick={onRetry}
-						className="shrink-0 text-sm font-medium text-pink-400 hover:text-pink-300"
+						className="cursor-pointer shrink-0 text-sm font-medium text-pink-400 transition-colors hover:text-pink-300"
 					>
 						Retry
 					</button>

--- a/entrypoints/options/components/FolderSelect.tsx
+++ b/entrypoints/options/components/FolderSelect.tsx
@@ -34,7 +34,7 @@ export const FolderSelect = ({ folders, value, onChange, disabled }: Props) => {
 				type="button"
 				onClick={() => !disabled && setOpen(!open)}
 				disabled={disabled}
-				className={`inline-flex w-full items-center justify-between rounded-md border bg-zinc-900 px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-40 focus:border-pink-500 focus:outline-none ${open ? "border-pink-500" : "border-zinc-700"} ${selected ? "text-zinc-100" : "text-zinc-500"}`}
+				className={`cursor-pointer inline-flex w-full items-center justify-between rounded-md border bg-zinc-900 px-3 py-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40 focus:border-pink-500 focus:outline-none ${open ? "border-pink-500" : "border-zinc-700"} ${selected ? "text-zinc-100" : "text-zinc-500"}`}
 			>
 				<span className="truncate">
 					{selected ? selected.path : "Select folder…"}
@@ -59,7 +59,7 @@ export const FolderSelect = ({ folders, value, onChange, disabled }: Props) => {
 									onChange(f.id, f.path);
 									setOpen(false);
 								}}
-								className={`w-full px-3 py-1.5 text-left text-sm ${f.id === value ? "bg-pink-500/10 text-pink-400" : "text-zinc-400 hover:bg-zinc-800"}`}
+								className={`w-full cursor-pointer px-3 py-1.5 text-left text-sm transition-colors ${f.id === value ? "bg-pink-500/10 text-pink-400" : "text-zinc-400 hover:bg-zinc-800"}`}
 							>
 								{f.path}
 							</button>

--- a/entrypoints/options/components/Header.tsx
+++ b/entrypoints/options/components/Header.tsx
@@ -31,7 +31,7 @@ export const Header = ({ state, user, onSignIn, onSignOut }: Props) => (
 					<button
 						type="button"
 						onClick={onSignOut}
-						className="rounded-md px-2.5 py-1 text-sm text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+						className="cursor-pointer rounded-md px-2.5 py-1 text-sm text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
 					>
 						Sign out
 					</button>
@@ -40,7 +40,7 @@ export const Header = ({ state, user, onSignIn, onSignOut }: Props) => (
 				<button
 					type="button"
 					onClick={onSignIn}
-					className="rounded-md bg-pink-500 px-3 py-1 text-sm font-medium text-white hover:bg-pink-600"
+					className="cursor-pointer rounded-md bg-pink-500 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-pink-600"
 				>
 					Sign in
 				</button>

--- a/entrypoints/options/components/LoginModal.tsx
+++ b/entrypoints/options/components/LoginModal.tsx
@@ -39,7 +39,7 @@ export const LoginModal = ({ open, deviceFlow, error, onCancel }: Props) => {
 							href={deviceFlow.verificationUri}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="w-full flex items-center justify-center gap-1 rounded-md bg-pink-500 p-2 text-sm font-medium text-white hover:bg-pink-600"
+							className="w-full flex items-center justify-center gap-1 rounded-md bg-pink-500 p-2 text-sm font-medium text-white transition-colors hover:bg-pink-600"
 						>
 							Open github.com/device
 							<ArrowRightIcon />
@@ -57,7 +57,7 @@ export const LoginModal = ({ open, deviceFlow, error, onCancel }: Props) => {
 					<button
 						type="button"
 						onClick={onCancel}
-						className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400"
+						className="cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400 transition-colors hover:bg-zinc-700"
 					>
 						Cancel
 					</button>

--- a/entrypoints/options/components/RepoCombobox.tsx
+++ b/entrypoints/options/components/RepoCombobox.tsx
@@ -72,7 +72,7 @@ export const RepoCombobox = ({ repos, loading, value, onChange }: Props) => {
 									setQuery("");
 									setOpen(false);
 								}}
-								className="w-full px-3 py-1.5 text-left text-sm text-zinc-400 hover:bg-zinc-800"
+								className="w-full cursor-pointer px-3 py-1.5 text-left text-sm text-zinc-400 transition-colors hover:bg-zinc-800"
 							>
 								{repo.full_name}
 							</button>

--- a/entrypoints/options/components/SyncButton.tsx
+++ b/entrypoints/options/components/SyncButton.tsx
@@ -11,7 +11,7 @@ export const SyncButton = ({ syncing, disabled, onPull }: Props) => (
 		type="button"
 		onClick={onPull}
 		disabled={disabled || syncing}
-		className="rounded-md bg-pink-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-pink-600 disabled:cursor-not-allowed disabled:opacity-40"
+		className="cursor-pointer rounded-md bg-pink-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-pink-600 disabled:cursor-not-allowed disabled:opacity-40"
 	>
 		{syncing ? (
 			<span className="inline-flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

- Add explicit `cursor-pointer` to every button and clickable element in the options page. Tailwind's preflight resets the browser default pointer cursor on `<button>`, so without this the cursor stays as an arrow on all interactive controls.
- Add `transition-colors` to elements whose background or text colour changes on `hover` or `focus` (primary/secondary buttons, dropdown options, toggle, inputs with `focus:border-*`, etc.) for smooth visual feedback.
- Align `disabled:cursor-not-allowed` across the board — toggle switch and Disconnect button previously omitted it.
- Add a subtle `hover` colour to Cancel buttons and the "Sign in required" chip that previously had no hover feedback.

## Test plan

- [ ] Hover over every button, link, and dropdown option — confirm pointer cursor appears
- [ ] Hover over primary buttons (Sign in, Sync, Add) — confirm bg-colour transition is smooth
- [ ] Hover over secondary buttons (Cancel, Save, Sign out) — confirm transition
- [ ] Hover/focus srcDir inputs — confirm border colour transition
- [ ] Verify disabled buttons (e.g. Sync while syncing, toggle while unauthenticated) show `not-allowed` cursor