### PR TITLE
refactor: remove redundant open prop from AddConnectionModal

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -178,7 +178,6 @@ const App = () => {
 				// unmount and reset all internal states when closed
 				addOpen && (
 					<AddConnectionModal
-						open={addOpen}
 						repos={repos}
 						reposLoading={reposLoading}
 						existingConnections={connections}

--- a/entrypoints/options/components/AddConnectionModal.tsx
+++ b/entrypoints/options/components/AddConnectionModal.tsx
@@ -12,7 +12,6 @@ import { FolderTree } from "./FolderTree.tsx";
 import { RepoCombobox } from "./RepoCombobox.tsx";
 
 type Props = {
-	open: boolean;
 	repos: Repository[];
 	reposLoading: boolean;
 	existingConnections: Connection[];
@@ -21,7 +20,6 @@ type Props = {
 };
 
 export const AddConnectionModal = ({
-	open,
 	repos,
 	reposLoading,
 	existingConnections,
@@ -42,8 +40,6 @@ export const AddConnectionModal = ({
 	const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 	const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
 	const [hasLoadedFolderTree, setHasLoadedFolderTree] = useState(false);
-
-	if (!open) return null;
 
 	const loadFolderTree = () => {
 		setFolderTreeLoading(true);


### PR DESCRIPTION
The modal is already conditionally rendered in the parent component
using 'addOpen &&', making the open prop unnecessary.
