### PR TITLE
fix: correct flex classes for LoginModal button layout

### DIFF
--- a/entrypoints/options/components/LoginModal.tsx
+++ b/entrypoints/options/components/LoginModal.tsx
@@ -122,7 +122,7 @@ export const LoginModal = ({
 							kind="secondary"
 							onClick={handleCancel}
 							disabled={loading}
-							className="grow-1"
+							className="flex-1 basis-full"
 						>
 							Cancel
 						</Button>
@@ -130,7 +130,7 @@ export const LoginModal = ({
 							kind="primary"
 							type="submit"
 							disabled={loading}
-							className="grow-1"
+							className="flex-1 basis-full"
 						>
 							{loading ? "Validating..." : "Sign in"}
 						</Button>


### PR DESCRIPTION
Fix button layout in LoginModal by replacing invalid `grow-1` class with proper `flex-1 basis-full` classes.